### PR TITLE
Change Attachments format

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem "puma"
 gem "dotenv-rails", require: "dotenv/rails-now"
 gem "foreman"
 
+gem "dragonfly"
 gem "slim-rails"
 gem "therubyracer", platforms: :ruby
 gem "uglifier"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,6 +38,8 @@ GEM
       i18n (~> 0.7)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+    addressable (2.5.1)
+      public_suffix (~> 2.0, >= 2.0.2)
     arel (8.0.0)
     ast (2.3.0)
     builder (3.2.3)
@@ -48,6 +50,10 @@ GEM
     dotenv-rails (2.2.1)
       dotenv (= 2.2.1)
       railties (>= 3.2, < 5.2)
+    dragonfly (1.1.2)
+      addressable (~> 2.3)
+      multi_json (~> 1.0)
+      rack (>= 1.3)
     erubi (1.6.0)
     execjs (2.7.0)
     factory_girl (4.8.0)
@@ -77,6 +83,7 @@ GEM
     mime-types-data (3.2016.0521)
     mini_portile2 (2.1.0)
     minitest (5.10.2)
+    multi_json (1.12.1)
     nio4r (2.0.0)
     nokogiri (1.7.2)
       mini_portile2 (~> 2.1.0)
@@ -84,6 +91,7 @@ GEM
       ast (~> 2.2)
     pg (0.20.0)
     powerpack (0.1.1)
+    public_suffix (2.0.5)
     puma (3.8.2)
     rack (2.0.2)
     rack-test (0.6.3)
@@ -185,6 +193,7 @@ PLATFORMS
 
 DEPENDENCIES
   dotenv-rails
+  dragonfly
   factory_girl_rails
   foreman
   listen

--- a/app/models/image_attachment.rb
+++ b/app/models/image_attachment.rb
@@ -1,1 +1,0 @@
-class ImageAttachment < Attachment; end

--- a/app/models/text_attachment.rb
+++ b/app/models/text_attachment.rb
@@ -1,1 +1,0 @@
-class TextAttachment < Attachment; end

--- a/config/initializers/dragonfly.rb
+++ b/config/initializers/dragonfly.rb
@@ -1,0 +1,26 @@
+require "dragonfly"
+
+# Configure
+Dragonfly.app.configure do
+  plugin :imagemagick
+
+  secret "2ad5c32f3501216a2d893671bb9fb91d35958fbfa85650f88de64e3ecad352db"
+
+  url_format "/media/:job/:name"
+
+  datastore :file,
+            root_path: Rails.root.join("public/system/dragonfly", Rails.env),
+            server_root: Rails.root.join("public")
+end
+
+# Logger
+Dragonfly.logger = Rails.logger
+
+# Mount as middleware
+Rails.application.middleware.use Dragonfly::Middleware
+
+# Add model functionality
+if defined?(ActiveRecord::Base)
+  ActiveRecord::Base.extend Dragonfly::Model
+  ActiveRecord::Base.extend Dragonfly::Model::Validations
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,8 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20_161_118_202_543) do
+ActiveRecord::Schema.define(version: 20161118202543) do
+
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -29,7 +30,7 @@ ActiveRecord::Schema.define(version: 20_161_118_202_543) do
     t.integer "attachable_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index %w[attachable_type attachable_id], name: "index_attachments_on_attachable_type_and_attachable_id"
+    t.index ["attachable_type", "attachable_id"], name: "index_attachments_on_attachable_type_and_attachable_id"
   end
 
   create_table "questions", id: :serial, force: :cascade do |t|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,11 +23,11 @@ RSpec.configure do |config|
     mocks.verify_partial_doubles = true
   end
 
+  config.default_formatter = "doc" if config.files_to_run.one?
   config.shared_context_metadata_behavior = :apply_to_host_groups
   config.filter_run_when_matching :focus
   config.example_status_persistence_file_path = "spec/examples.txt"
   config.disable_monkey_patching!
-  config.default_formatter = "doc"
   config.profile_examples = 10
   config.order = :random
 


### PR DESCRIPTION
Mudei umas coisas:
 - Coloquei pra usar o dragonfly, só não tá configurado pra usar o S3
 - Tirei as classes de STI pra Attachment, a gente pode só verificar pelo atributo `type` mesmo;
 - Tirei aquele JSON da tabela de Attachment também. Eu não lembro exatamente pra o que a gente ia precisar dele, mas, além do nome, que já é salvo por causa da coluna que eu coloquei pro dragonfly usar, eu acho que qualquer outra informação que a gente for precisar guardar sobre um attachment a gente pode usar o `meta` do dragonfly: http://markevans.github.io/dragonfly/models#meta-data